### PR TITLE
fix: scope Window index signature to `Trackstar*` keys (pylon #3870)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trackstar/react-trackstar-link",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A React component to open the Trackstar Connect Modal",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,6 @@ export interface Trackstar {
 declare global {
   interface Window {
     Trackstar: Trackstar;
-    [trackstarModalId: string]: Trackstar;
+    [key: `Trackstar${string}`]: Trackstar;
   }
 }

--- a/src/useTrackstarLink.ts
+++ b/src/useTrackstarLink.ts
@@ -9,7 +9,7 @@ export default function useTrackstarLink(config: ClientConfig) {
     // src: "http://localhost:3005/main.js",
     checkForExisting: true,
   });
-  const trackstarModalId = config.hasOwnProperty("buttonId") ? "Trackstar" + config.buttonId : "Trackstar";
+  const trackstarModalId = (config.hasOwnProperty("buttonId") ? "Trackstar" + config.buttonId : "Trackstar") as `Trackstar${string}`;
   const modal = typeof window !== 'undefined' && window.Trackstar
 
   useEffect(() => {


### PR DESCRIPTION
reported by Brandon (ApparelMagic) in [pylon #3870](https://app.usepylon.com/issues?issueNumber=3870). the `[trackstarModalId: string]: Trackstar` signature on `Window` leaks into consumers — every `window["foo"] = bar` in their app gets typed as `Trackstar`, so any non-`Trackstar` assignment fails with `TS2322`.

scoping the signature to `` `Trackstar${string}` `` keeps our own `window[trackstarModalId]` working while freeing up every other window key. also quietly fixes 213 `TS2411` errors the SDK has been emitting against `lib.dom.d.ts` (hidden by rollup at publish time).

added a template-literal cast on the dynamic `trackstarModalId` in `useTrackstarLink.ts` so our internal usage still compiles. bumped to `2.2.1`.

tested: `tsc --noEmit` goes 213 → 0, rollup build clean, strict-mode repro of Brandon's code compiles. still want to smoke-test in a consumer app before publishing.